### PR TITLE
Decode possible url %2b chars into + sign

### DIFF
--- a/app/presenters/user_list_presenter.rb
+++ b/app/presenters/user_list_presenter.rb
@@ -1,41 +1,46 @@
 class UserListPresenter
   attr_reader :type, :language, :location
-  
+
   def initialize(params)
     @type = (params.keys.map(&:to_sym) & [:city, :country]).first || :world
     @page = [params[:page].to_i, 1].max
     @location = params.with_indifferent_access[@type].try(:downcase).try(:strip)
-    @language = params[:language] || "JavaScript"
+    @language = get_language(params)
   end
-  
+
+  def get_language(params)
+    lang = params[:language] || "JavaScript"
+    URI.decode_www_form_component(lang)
+  end
+
   def languages
     Languages::Index.get(sort: :popularity).map {|language| [language, language.downcase] }
   end
-  
+
   def title
     @type==:world ? "worldwide" : "in #{@location.capitalize}"
   end
-  
+
   def show_location_input?
     @type != :world
   end
-  
+
   def empty_message
     "Could not find any user for <strong> #{@type} </strong> '#{ERB::Util.html_escape @location}'. Use the auto completion to avoid spelling errors, or go to Top users by country for country search".html_safe
   end
-  
+
   def location_input
     ActionController::Base.helpers.text_field_tag @type, @location.capitalize, class: "form-control"
   end
-  
+
   def rank_label
     "#{@type.capitalize} rank"
   end
-  
+
   def ranking(user_rank)
     user_rank.send("#{@type}_rank")
   end
-  
+
   def user_ranks
     top_rank = TopRank.new(type: @type, language: @language, location: @location)
     user_ranks = top_rank.user_ranks(page: @page, per: 25)

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -21,6 +21,10 @@ describe Api::V0::UsersController, :users_api_spec do
     @sherlockholmes = FactoryGirl.create(:user, login: 'sherlockholmes', city: 'san francisco', country: 'us', gravatar_url: 'url')
     FactoryGirl.create(:repository, language: 'javascript', user: @sherlockholmes, stars: 5)
 
+    @bb8 = FactoryGirl.create(:user, login: 'bb8', city: 'Los Angeles', country: 'us', gravatar_url: 'url')
+    FactoryGirl.create(:repository, language: 'c++', user: @bb8, stars: 5)
+
+
     $redis.zadd("user_ruby_paris", 1.1, @vdaubry.id)
     $redis.zadd("user_ruby", 1.1, @vdaubry.id)
     $redis.zadd("user_swift_lisbon", 5.0, @nunogoncalves.id)
@@ -29,6 +33,8 @@ describe Api::V0::UsersController, :users_api_spec do
     $redis.zadd("user_javascript", 0.2, @walterwhite.id)
     $redis.zadd("user_javascript_san_francisco", 0.5, @sherlockholmes.id)
     $redis.zadd("user_javascript", 0.5, @sherlockholmes.id)
+    $redis.zadd("user_c++_los_angeles", 0.7, @bb8.id)
+    $redis.zadd("user_c++", 0.7, @bb8.id)
   end
 
   context 'GET#index' do
@@ -59,6 +65,12 @@ describe Api::V0::UsersController, :users_api_spec do
         expect(first_user['stars_count']).to eq(3)
       end
 
+      it 'should return c++ users when request has url encoded plus sign' do
+        get :index, language: "c%2B%2B", city: 'los angeles'
+
+        first_user = response_hash['users'].first
+        expect(first_user['login']).to eq('bb8')
+      end
     end
 
     context 'without scope' do


### PR DESCRIPTION
Building the iOS app, I noticed no c++ users were being returned from the server. 

I realised it has to do with url encoding. Since + is a valid url character, it gets translated into a space in the server (tested it locally as well). I have to replace a + sign into it’s url form %2B. In this case we have to update the server to convert this character back into the plus sign. 

If you don’t like this approach let me know. :) 