### PR TITLE
Adding number of users for each language in get languages endpoint

### DIFF
--- a/app/controllers/api/v0/languages_controller.rb
+++ b/app/controllers/api/v0/languages_controller.rb
@@ -6,8 +6,9 @@ module Api
 
       def index
         sort = params["sort"].try(:to_sym) || :alphabetical
-        languages = Languages::Index.get(sort: sort)
-        respond({languages: languages}, :ok)
+        with_count = params["with_count"] || false
+        languages = Languages::Index.get({ sort: sort, with_count: with_count })
+        respond({ languages: languages }, :ok)
       end
 
     end

--- a/app/usecases/languages/index.rb
+++ b/app/usecases/languages/index.rb
@@ -3,16 +3,34 @@ module Languages
 
     class << self
 
-      def get(sort: :alphabetical)
-        languages = Rails.cache.fetch('languages') do
+      attr_accessor :languages
+
+      def get(context)
+        read_languages
+        languages.sort! if context[:sort] == :alphabetical
+        add_users_count if ["true", true].include?(context[:with_count])
+        languages
+      end
+
+      private
+
+      def read_languages
+        @languages = Rails.cache.fetch('languages') do
           file_contents = File.read(languages_file)
           JSON.parse(file_contents).compact
         end
-        sort == :alphabetical ? languages.sort : languages
+      end
+
+      def add_users_count
+        languages.map! { |l| { "#{l}" => users_for_language(l) } }
       end
 
       def languages_file
         Rails.root.join('app/assets/json/languages.json')
+      end
+
+      def users_for_language(language)
+        $redis.zcard("user_#{language}".redis_key)
       end
 
     end

--- a/spec/controllers/api/languages_controller_spec.rb
+++ b/spec/controllers/api/languages_controller_spec.rb
@@ -36,5 +36,17 @@ describe Api::V0::LanguagesController do
         expect(response_hash['languages']).to eq(["C#","JavaScript","Ruby"])
       end
     end
+
+    context "return with user count" do
+      it 'should return a list of languages with users count' do
+        get :index, sort: :alphabetical, with_count: true
+        expect(response_hash['languages']).to eq([
+          { "C#" => 0 },
+          { "JavaScript" => 0 },
+          { "Ruby" => 0 }
+        ])
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hi @vdaubry 

I decided to make it an option because up until now the return was an array of strings instead of objects.

Since I have the app in production it would break things (V1 should have the return type always as a Language object (name: "", users:""... whatever). This way it wouldn't break things when adding fields like this example.

So in this case if we send the boolean, we get an array of objects, if not we still get an array of strings..
Not perfect, but what I came up with. 

Let me know what you think.