### PR TITLE
swagger: change base path to the production URL

### DIFF
--- a/public/docs/api-docs.json
+++ b/public/docs/api-docs.json
@@ -1,7 +1,7 @@
 {
   "apiVersion": "0",
   "swaggerVersion": "1.2",
-  "basePath": "http://localhost:3000/",
+  "basePath": "http://git-awards.com/",
   "apis": [
     {
       "path": "/docs/api/v0/users.{format}",

--- a/public/docs/api/v0/languages.json
+++ b/public/docs/api/v0/languages.json
@@ -1,7 +1,7 @@
 {
   "apiVersion": "0",
   "swaggerVersion": "1.2",
-  "basePath": "http://localhost:3000/",
+  "basePath": "http://git-awards.com/",
   "resourcePath": "languages",
   "apis": [
     {

--- a/public/docs/api/v0/users.json
+++ b/public/docs/api/v0/users.json
@@ -1,7 +1,7 @@
 {
   "apiVersion": "0",
   "swaggerVersion": "1.2",
-  "basePath": "http://localhost:3000/",
+  "basePath": "http://git-awards.com/",
   "resourcePath": "users",
   "apis": [
     {


### PR DESCRIPTION
This is the quick-and-easy way to fix #124 . Or is it preferred to change the swagger docs from public assets to regular views and inject hostname based on request data or configuration?