### PR TITLE
API: Users: add 'type' property

### DIFF
--- a/app/models/top_rank.rb
+++ b/app/models/top_rank.rb
@@ -17,7 +17,7 @@ class TopRank
 
     users = User.find_as_sorted(results)
                 .joins(:repositories)
-                .select("users.id, users.city, users.country, users.gravatar_url, users.login, sum(stars) AS stars_count, count(repositories.id) as repository_count")
+                .select("users.id, users.city, users.country, users.gravatar_url, users.login, users.organization, sum(stars) AS stars_count, count(repositories.id) as repository_count")
                 .where(repositories: {language: language})
                 .group("users.id")
 

--- a/app/serializers/api/v0/user_serializer.rb
+++ b/app/serializers/api/v0/user_serializer.rb
@@ -6,7 +6,12 @@ module Api
                    :login,
                    :gravatar_url,
                    :city,
-                   :country
+                   :country,
+                   :type
+
+        def type
+          object.organization? ? 'organization' : 'user'
+        end
     end
   end
 end

--- a/public/docs/api/v0/users.json
+++ b/public/docs/api/v0/users.json
@@ -138,7 +138,8 @@
         "country",
         "city_rank",
         "country_rank",
-        "world_rank"
+        "world_rank",
+        "type"
       ],
       "properties": {
         "id": {
@@ -176,6 +177,11 @@
         "worldRank": {
           "type": "integer",
           "description": "The world rank of the user"
+        },
+        "type": {
+          "type": "string",
+          "description": "User type",
+          "enum": ["user", "organization"]
         }
       }
     },
@@ -199,7 +205,8 @@
         "gravatar_url",
         "city",
         "country",
-        "rankings"
+        "rankings",
+        "type"
       ],
       "properties": {
         "id": {
@@ -228,6 +235,11 @@
           "items": {
             "$ref": "user_ranking"
           }
+        },
+        "type": {
+          "type": "string",
+          "description": "User type",
+          "enum": ["user", "organization"]
         }
       }
     },

--- a/spec/controllers/api/users_controller_spec.rb
+++ b/spec/controllers/api/users_controller_spec.rb
@@ -24,6 +24,8 @@ describe Api::V0::UsersController, :users_api_spec do
     @bb8 = FactoryGirl.create(:user, login: 'bb8', city: 'Los Angeles', country: 'us', gravatar_url: 'url')
     FactoryGirl.create(:repository, language: 'c++', user: @bb8, stars: 5)
 
+    @org = FactoryGirl.create(:organization, login: 'org')
+
 
     $redis.zadd("user_ruby_paris", 1.1, @vdaubry.id)
     $redis.zadd("user_ruby", 1.1, @vdaubry.id)
@@ -119,6 +121,15 @@ describe Api::V0::UsersController, :users_api_spec do
       expect(user['login']).to eq('nunogoncalves')
       expect(user['city']).to eq('lisbon')
       expect(user['country']).to eq('portugal')
+      expect(user['type']).to eq('user')
+    end
+
+    context 'organization' do
+      it 'should return correct type' do
+        get :show, login: 'org'
+
+        expect(response_hash['user']['type']).to eq('organization')
+      end
     end
 
     it 'should return propper ranking information', :t do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,5 +11,9 @@ FactoryGirl.define do
     city              "string"
     github_id         123
     processed         false
+
+    factory :organization do
+      organization    true
+    end
   end
 end


### PR DESCRIPTION
Fixes the first issue mentioned in #128 :

> At the moment it's impossible to distinguish between users and organizations from the API search results. Adding a type (user, org) would allow to differentiate between them.