### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://semaphoreci.com/api/v1/projects/aa2cd6ce-b19d-43bc-9db1-f1c3c2756be9/389922/badge.svg)](https://semaphoreci.com/vdaubry/github-awards)      
+[![Build Status](https://semaphoreci.com/api/v1/projects/aa2cd6ce-b19d-43bc-9db1-f1c3c2756be9/389922/badge.svg)](https://semaphoreci.com/vdaubry/github-awards)
+[![Help Contribute to Open Source](https://www.codetriage.com/vdaubry/github-awards/badges/users.svg)](https://www.codetriage.com/vdaubry/github-awards)
 
 # Important notice : Github Awards becomes Git Awards !
 
@@ -12,7 +13,7 @@ Git Awards gives your ranking on GitHub by language and by location (city, count
 In order to calculate your ranking on GitHub we:
 - Get all GitHub users with their location
 - Geocode their location
-- Get all GitHub repositories with language and number of stars 
+- Get all GitHub repositories with language and number of stars
 
 With this information we are able to compute your ranking for a given language in a given city.
 
@@ -34,7 +35,7 @@ Rake tasks are :
 Now we need to get detailed informations such as location, language, number of stars.
 
 
-## Step 2 : Use Google Big Query to get details about active users and repositories 
+## Step 2 : Use Google Big Query to get details about active users and repositories
 
 > GitHub Archive is a project to record the public GitHub timeline, archive it, and make it easily accessible for further analysis.
 
@@ -108,6 +109,6 @@ Next steps :
 * Push to the branch `git push origin my-new-feature`
 * Create a new Pull Request
 
-## License 
+## License
 
 This project is available under the MIT license. [See the license file](LICENSE.md) for more details.


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.